### PR TITLE
Remove Return Type Declarations - php5 friendly

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -89,7 +89,7 @@ class helper {
      * difference, which of the Moodle hooks were used. It appears that the requirejs module loader itself runs too
      * late, i.e. after the events of interest to us here.
      */
-    public static function enable_notifications() : string {
+    public static function enable_notifications() {
         global $PAGE, $USER;
         $conf = get_config('local_csp');
         $cansee = false;
@@ -136,7 +136,7 @@ class helper {
      * @param array $records Array of local_csp records with matching sha1hash. Must contain at least two records.
      * @return \stdClass The final object representing a local_csp record once all records are merged into one.
      */
-    public static function merge_duplicate_records(array $records): \stdClass {
+    public static function merge_duplicate_records(array $records) {
         global $DB;
         // If no records provided, there is no object to return so throw exception.
         if (empty($records)) {

--- a/lib.php
+++ b/lib.php
@@ -28,7 +28,7 @@
  * The script for the event listener is injected into the page header.
  * This is done at this early stage to ensure that the event listener is in place before the events start coming.
  */
-function local_csp_before_standard_html_head() : string {
+function local_csp_before_standard_html_head() {
     return \local_csp\helper::enable_notifications();
 }
 


### PR DESCRIPTION
Explicit function return type declarations are incompatible with PHP5. Could these please be removed?