### PR TITLE
add Moodle 4.4 hooks

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_csp;
+
+use core\hook\output\before_http_headers;
+use core\hook\output\before_standard_head_html_generation;
+
+/**
+ * Hook callbacks for local_csp
+ *
+ * @package    local_csp
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+    /**
+     * Callback to add head elements.
+     * @param \core\hook\output\before_standard_head_html_generation $hook
+     */
+    public static function before_standard_head_html_generation(before_standard_head_html_generation $hook): void {
+        $hook->add_html(\local_csp\helper::enable_notifications());
+    }
+
+    /**
+     * Callback to add http headers.
+     * @param \core\hook\output\before_http_headers $hook
+     */
+    public static function before_http_headers(before_http_headers $hook): void {
+        \local_csp\helper::enable_csp_header();
+        \local_csp\helper::enable_feature_policy();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,19 +15,22 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * moodle-local_csp settings.
+ * Hook callbacks for local_csp
  *
- * @package   local_csp
- * @author    Suan Kan <suankan@catalyst-au.net>
- * @copyright Catalyst IT
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    local_csp
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024031401;
-$plugin->release = 2024031401;
-$plugin->requires = 2015051100;
-$plugin->maturity = MATURITY_STABLE;
-$plugin->component = 'local_csp';
-$plugin->supported = [401, 404];
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_head_html_generation::class,
+        'callback' => [\local_csp\hook_callbacks::class, 'before_standard_head_html_generation'],
+    ],
+    [
+        'hook' => \core\hook\output\before_http_headers::class,
+        'callback' => [\local_csp\hook_callbacks::class, 'before_http_headers'],
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -27,6 +27,9 @@
  * A listener is registered for the `securitypolicyviolation` event and the JS for the notifications is loaded.
  * The script for the event listener is injected into the page header.
  * This is done at this early stage to ensure that the event listener is in place before the events start coming.
+ *
+ * This is a legacy callback that is used for compatibility with older Moodle versions.
+ * Moodle 4.4+ will use local_csp\hook_callbacks::before_standard_head_html_generation instead.
  */
 function local_csp_before_standard_html_head() : string {
     return \local_csp\helper::enable_notifications();
@@ -43,6 +46,9 @@ function local_csp_extend_navigation() {
 /**
  * Moodle native lib/navigationlib.php calls this hook allowing us to override UI.
  * Here we instruct Moodle website to issue custom HTTP response header Content-Security-Policy-Report-Only on every page.
+ *
+ * This is a legacy callback that is used for compatibility with older Moodle versions.
+ * Moodle 4.4+ will use local_csp\hook_callbacks::before_http_headers instead.
  */
 function local_csp_before_http_headers() {
     \local_csp\helper::enable_csp_header();


### PR DESCRIPTION
This ought to be what's needed to fix issue #84 with Moodle 4.4+ superseding the 'before_standard_html_head' and 'before_http_headers' plugin callbacks.
