### PR TITLE
Change hook callback to string

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -27,10 +27,10 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core\hook\output\before_standard_head_html_generation::class,
-        'callback' => [\local_csp\hook_callbacks::class, 'before_standard_head_html_generation'],
+        'callback' => '\local_csp\hook_callbacks::before_standard_head_html_generation',
     ],
     [
         'hook' => \core\hook\output\before_http_headers::class,
-        'callback' => [\local_csp\hook_callbacks::class, 'before_http_headers'],
+        'callback' => '\local_csp\hook_callbacks::before_http_headers',
     ],
 ];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024052200;
-$plugin->release = 2024052200;
+$plugin->version = 2024052400;
+$plugin->release = 2024052400;
 $plugin->requires = 2015051100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_csp';


### PR DESCRIPTION
Changes the new hook callback back to a string for greater compatibility as it was causing some issues in 4.3, for example https://github.com/catalyst/moodle-auth_outage/issues/336