### PR TITLE
Add export

### DIFF
--- a/classes/table/csp_report.php
+++ b/classes/table/csp_report.php
@@ -131,7 +131,11 @@ class csp_report extends \table_sql {
         }
         $label = str_replace($CFG->wwwroot, '', $label);
         $label = ltrim($label, '/');
-        $label = shorten_text($label, $size, true);
+
+        // Only shorten text when not exporting.
+        if (!$this->is_downloading()) {
+            $label = shorten_text($label, $size, true);
+        }
         $label = s($label);
 
         return \html_writer::link($uri, $label);
@@ -287,6 +291,11 @@ class csp_report extends \table_sql {
      * @return string HTML link.
      */
     protected function col_action($record) {
+        // Output no action if exporting.
+        if ($this->is_downloading()) {
+            return '';
+        }
+
         global $OUTPUT;
 
         // Find whether we are drilling down.


### PR DESCRIPTION
**Changes**

- Adds `table_sql`'s built in downloading function, allowing users to download the report:

![image](https://github.com/catalyst/moodle-local_csp/assets/17095477/94abfe99-faf3-42da-8ff9-aa2b5ea94dd6)

As part of this:
- The URIs are fully expanded in download mode (truncated normally)
- The action column is empty when exporting (to avoid accidental clicking to delete result in HTML export). While it would be ideal to remove the column altogether, it is far simpler code-wise with the current layout of the page to just simply make it empty.

**Testing**

Manual testing:
1. Enabled CSP headers in plugin settings
2. Went to CSP test page, this generates csp reports
3. Went to CSP report page, downloaded main report, works as expected
4. Drilled down into CSP reports by clicking on number at start of one of the rows
5. Downloaded drill-down report, works as expected

| Main export | Drill down export |
|--------|--------|
| ![image](https://github.com/catalyst/moodle-local_csp/assets/17095477/ed91ff7f-81a0-40ee-887f-f0f95c2cb421) | ![image](https://github.com/catalyst/moodle-local_csp/assets/17095477/884f20a4-235d-43f1-8ac4-3a676d9aeaf1) |
