### PR TITLE
Add violation hash and index #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci](https://github.com/catalyst/moodle-local_csp/actions/workflows/ci.yml/badge.svg?branch=MOODLE_401_STABLE)](https://github.com/catalyst/moodle-local_csp/actions/workflows/ci.yml?branch=MOODLE_401_STABLE)
+[![ci](https://github.com/catalyst/moodle-local_csp/actions/workflows/ci.yml/badge.svg?branch=MOODLE_500_STABLE)](https://github.com/catalyst/moodle-local_csp/actions/workflows/ci.yml?branch=MOODLE_500_STABLE)
 
 # moodle-local_csp
 
@@ -62,7 +62,8 @@ Branches
 
 | Moodle verion     | Branch                | PHP       |
 | ----------------- | --------------------- | --------  |
-| Moodle 4.1+       | MOODLE_401_STABLE     | 7.4       |
+| Moodle 5.0+       | MOODLE_500_STABLE     | 8.3       |
+| Moodle 4.1 to 4.5 | MOODLE_401_STABLE     | 7.4       |
 | Moodle 3.3 to 4.0 | master                | 7.2       |
 | Moodle 2.7        | MOODLE_27_STABLE      | 5.5       |
 

--- a/classes/task/add_violationhash_task.php
+++ b/classes/task/add_violationhash_task.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_csp\task;
+
+use core\task\adhoc_task;
+
+/**
+ * Adds violationhash to all CSP records.
+ *
+ * This is essentially a one off upgrade task that was moved to the background
+ * because it can take a long time for large datasets.
+ *
+ * @package    local_csp
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class add_violationhash_task extends adhoc_task {
+    /**
+     * Get task name.
+     */
+    public function get_name(): string {
+        return get_string('add_violationhash_task', 'local_csp');
+    }
+
+    /**
+     * Execute the task.
+     */
+    public function execute(): void {
+        global $DB;
+
+        // Get a recordset of all the unique violateddirect and blockeddomain pairs.
+        $recordset = $DB->get_recordset_sql("
+            SELECT violateddirective, blockeddomain, count(*) as count
+              FROM {local_csp}
+             WHERE violationhash IS NULL
+          GROUP BY violateddirective, blockeddomain
+          ORDER BY count DESC
+        ");
+
+        // Iterate through each pair and update the records.
+        foreach ($recordset as $record) {
+            $violationhash = sha1($record->violateddirective . $record->blockeddomain);
+            $DB->set_field('local_csp', 'violationhash', $violationhash, [
+                'violationhash' => null,
+                'violateddirective' => $record->violateddirective,
+                'blockeddomain' => $record->blockeddomain,
+            ]);
+        }
+        $recordset->close();
+    }
+}

--- a/collector.php
+++ b/collector.php
@@ -77,6 +77,7 @@ if ($cspreport) {
             $dataobject->timecreated = $timestamp;
             $dataobject->timeupdated = $timestamp;
             $dataobject->sha1hash = $hash;
+            $dataobject->violationhash = sha1($dataobject->violateddirective . $dataobject->blockeddomain);
             $dataobject->failcounter = 1;
             $DB->insert_record('local_csp', $dataobject);
             echo "OK\n";

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/csp/db" VERSION="20200324" COMMENT="XMLDB file for Moodle local/csp"
+<XMLDB PATH="local/csp/db" VERSION="20250102" COMMENT="XMLDB file for Moodle local/csp"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -17,6 +17,7 @@
         <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="timeupdated" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="sha1hash" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false" COMMENT="This is a sha1 hash over columns documenturi, blockeduri and violateddirective."/>
+        <FIELD NAME="violationhash" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false" COMMENT="This is a sha1 hash over columns violateddirective and blockeddomain."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -24,6 +25,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="mdl_local_csp_sha1hash_ix" UNIQUE="false" FIELDS="sha1hash" COMMENT="To help searching for existing records."/>
+        <INDEX NAME="violationhash" UNIQUE="false" FIELDS="violationhash"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -113,6 +113,30 @@ function xmldb_local_csp_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022060300, 'local', 'csp');
     }
 
+    if ($oldversion < 2025012901) {
+
+        // Define field violationhash to be added to local_csp.
+        $table = new xmldb_table('local_csp');
+        $field = new xmldb_field('violationhash', XMLDB_TYPE_CHAR, '40', null, null, null, null, 'sha1hash');
+
+        // Conditionally launch add field violationhash.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        $index = new xmldb_index('violationhash', XMLDB_INDEX_NOTUNIQUE, ['violationhash']);
+
+        // Conditionally launch add index violationhash.
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        \core\task\manager::queue_adhoc_task(new \local_csp\task\add_violationhash_task());
+
+        // CSP savepoint reached.
+        upgrade_plugin_savepoint(true, 2025012901, 'local', 'csp');
+    }
+
     return true;
 }
 

--- a/lang/en/local_csp.php
+++ b/lang/en/local_csp.php
@@ -26,6 +26,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $string['action'] = 'Action';
+$string['add_violationhash_task'] = 'Add violation hash to CSP records task';
 $string['areyousuretodeleteallrecords'] = 'Are you sure to delete all CSP report records?';
 $string['areyousuretodeleteonerecord'] = 'Are you sure to delete this CSP report record?';
 $string['blockeddomain'] = 'Domain';

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025010200;
-$plugin->release = 2025010200;
+$plugin->version = 2025012900;
+$plugin->release = 2025012900;
 $plugin->requires = 2015051100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_csp';
-$plugin->supported = [401, 405];
+$plugin->supported = [500, 500];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025012900;
-$plugin->release = 2025012900;
+$plugin->version = 2025012901;
+$plugin->release = 2025012901;
 $plugin->requires = 2015051100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_csp';


### PR DESCRIPTION
Adding the hash can take a long time on sites with a large amount of data. This shouldn't be a problem for sites properly curating data, but is a realistic possibility for sites that enabled report mode and have done nothing with it to have many millions of rows. As such, it was proposed to try and have this correspond with an upgrade.

To accomplish this the MOODLE_500_STABLE branch was created. It is essentially a placeholder that only contains this update for now, but proper support for Moodle 5.0 will be added at a later time if any changes are needed.